### PR TITLE
fix(ios): fix notification crash when debug=true

### DIFF
--- a/ios/CDVBackgroundGeolocation/CDVBackgroundGeolocation.m
+++ b/ios/CDVBackgroundGeolocation/CDVBackgroundGeolocation.m
@@ -449,14 +449,9 @@ static NSString * const TAG = @"CDVBackgroundGeolocation";
  */
 -(void) onFinishLaunching:(NSNotification *)notification
 {
-    if (@available(iOS 10, *)) {
-        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-        center.delegate = self;
-    }
-    
     NSDictionary *dict = [notification userInfo];
-
     MAURConfig *config = [facade getConfig];
+
     if (config.isDebugging)
     {
         if (@available(iOS 10, *))
@@ -469,7 +464,6 @@ static NSString * const TAG = @"CDVBackgroundGeolocation";
 
     if ([dict objectForKey:UIApplicationLaunchOptionsLocationKey]) {
         NSLog(@"%@ %@", TAG, @"started by system on location event.");
-        MAURConfig *config = [facade getConfig];
         if (![config stopOnTerminate]) {
             [facade start:nil];
             [facade switchMode:MAURBackgroundMode];


### PR DESCRIPTION
At the beginning of `onFinishLaunching`, `center.delegate` is set to
`self`. Later on, when debugging is enabled, the current value of
`center.delegate` is saved info `prevNotificationDelegate`. Since this
has already been set to `self`, a recursion and later a stack overflow
happens.

The commit that added the code
  80be0fd ("iOS avoid taking control of UNUserNotificationCenter", 2018-08-20)
has not removed the block at the beginning, but the original one referenced
there did:
  https://github.com/mauron85/react-native-background-geolocation/pull/268/files

So that was probably a mis-merge.

Fixes #565